### PR TITLE
Add Conjugate-Gradient solver for Poisson system

### DIFF
--- a/mae6225/grid/grid.py
+++ b/mae6225/grid/grid.py
@@ -52,6 +52,7 @@ class GridBase(object):
         self.set_default_bc()
         if user_bc_type is not None and user_bc_val is not None:
             self.set_user_bc(user_bc_type, user_bc_val)
+        self.fill_guard_cells(var_names)
 
     def __repr__(self):
         """Return a representation of the object."""
@@ -309,15 +310,15 @@ class GridBase(object):
             Grid-cell width.
 
         """
-        idx = self.vars[var_name]
+        var = self.get_values(var_name)
         if loc == 'left':
-            self.data[:, 0, idx] = bc_val * delta + self.data[:, 1, idx]
+            var[0, :] = bc_val * delta + var[1, :]
         elif loc == 'right':
-            self.data[:, -1, idx] = bc_val * delta + self.data[:, -2, idx]
+            var[-1, :] = bc_val * delta + var[-2, :]
         elif loc == 'bottom':
-            self.data[0, :, idx] = bc_val * delta + self.data[1, :, idx]
+            var[:, 0] = bc_val * delta + var[:, 1]
         elif loc == 'top':
-            self.data[-1, :, idx] = bc_val * delta + self.data[-2, :, idx]
+            var[:, -1] = bc_val * delta + var[:, -2]
         else:
             raise ValueError('Unknown boundary location "{}"'.format(loc))
 
@@ -363,15 +364,15 @@ class GridCellCentered(GridBase):
             Neumann boundary value.
 
         """
-        idx = self.vars[var_name]
+        var = self.get_values(var_name)
         if loc == 'left':
-            self.data[:, 0, idx] = 2.0 * bc_val - self.data[:, 1, idx]
+            var[0, :] = 2 * bc_val - var[1, :]
         elif loc == 'right':
-            self.data[:, -1, idx] = 2.0 * bc_val - self.data[:, -2, idx]
+            var[-1, :] = 2 * bc_val - var[-2, :]
         elif loc == 'bottom':
-            self.data[0, :, idx] = 2.0 * bc_val - self.data[1, :, idx]
+            var[:, 0] = 2 * bc_val - var[:, 1]
         elif loc == 'top':
-            self.data[-1, :, idx] = 2.0 * bc_val - self.data[-2, :, idx]
+            var[:, -1] = 2 * bc_val - var[:, -2]
         else:
             raise ValueError('Unknown boundary location "{}"'.format(loc))
 
@@ -415,15 +416,15 @@ class GridFaceX(GridBase):
             Neumann boundary value.
 
         """
-        idx = self.vars[var_name]
+        var = self.get_values(var_name)
         if loc == 'left':
-            self.data[0, :, idx] = bc_val
+            var[0, :] = bc_val
         elif loc == 'right':
-            self.data[-1, :, idx] = bc_val
+            var[-1, :] = bc_val
         elif loc == 'bottom':
-            self.data[:, 0, idx] = 2.0 * bc_val - self.data[:, 1, idx]
+            var[:, 0] = 2 * bc_val - var[:, 1]
         elif loc == 'top':
-            self.data[:, -1, idx] = 2.0 * bc_val - self.data[:, -2, idx]
+            var[:, -1] = 2 * bc_val - var[:, -2]
         else:
             raise ValueError('Unknown boundary location "{}"'.format(loc))
 
@@ -467,15 +468,15 @@ class GridFaceY(GridBase):
             Neumann boundary value.
 
         """
-        idx = self.vars[var_name]
+        var = self.get_values(var_name)
         if loc == 'left':
-            self.data[0, :, idx] = 2.0 * bc_val - self.data[1, :, idx]
+            var[0, :] = 2 * bc_val - var[1, :]
         elif loc == 'right':
-            self.data[-1, :, idx] = 2.0 * bc_val - self.data[-2, :, idx]
+            var[-1, :] = 2 * bc_val - var[-2, :]
         elif loc == 'bottom':
-            self.data[:, 0, idx] = bc_val
+            var[:, 0] = bc_val
         elif loc == 'top':
-            self.data[:, -1, idx] = bc_val
+            var[:, -1] = bc_val
         else:
             raise ValueError('Unknown boundary location "{}"'.format(loc))
 

--- a/mae6225/poisson/__init__.py
+++ b/mae6225/poisson/__init__.py
@@ -1,3 +1,4 @@
+from .cg import *
 from .gauss import *
 from .jacobi import *
 from .sor import *

--- a/mae6225/poisson/cg.py
+++ b/mae6225/poisson/cg.py
@@ -44,14 +44,14 @@ def solve_cg(grid, ivar, rvar, maxiter=1000, tol=1e-9, verbose=False):
         x[:, 0] = bc_val * dy + x[:, 1]
         x[:, -1] = bc_val * dy + x[:, -2]
 
-    p = grid.get_values(ivar)
-    b = grid.get_values(rvar)
-    dx, dy = grid.dx, grid.dy
+    p = grid.get_values(ivar)  # initial guess
+    b = grid.get_values(rvar)  # RHS of the system
+    dx, dy = grid.dx, grid.dy  # cell widths
 
-    r = b[1:-1, 1:-1] - A(p)
-    rk_norm = numpy.sum(r * r)
-    d = numpy.zeros_like(p)
-    d[1:-1, 1:-1] = r
+    r = b[1:-1, 1:-1] - A(p)  # initial residuals
+    rk_norm = numpy.sum(r * r)  # inner product
+    d = numpy.zeros_like(p)  # search direction
+    d[1:-1, 1:-1] = r  # set direction to initial residual
 
     # Check for Neumann boundary conditions.
     bc_type, bc_val = grid.bc_type[ivar][0], grid.bc_val[ivar][0]
@@ -59,18 +59,18 @@ def solve_cg(grid, ivar, rvar, maxiter=1000, tol=1e-9, verbose=False):
         # Apply Neumann boundary conditions to search direction.
         fill_guard_cells_neumann(d, bc_val, dx, dy)
 
-    ites = 0
-    res = tol + 1.0
+    ites = 0  # iteration index
+    res = tol + 1.0  # initial residual
     while ites < maxiter and res > tol:
         Ad = A(d)
-        alpha = rk_norm / numpy.sum(d[1:-1, 1:-1] * Ad)
-        p[1:-1, 1:-1] += alpha * d[1:-1, 1:-1]
+        alpha = rk_norm / numpy.sum(d[1:-1, 1:-1] * Ad)  # step size
+        p[1:-1, 1:-1] += alpha * d[1:-1, 1:-1]  # update solution
         grid.fill_guard_cells(ivar)
-        r -= alpha * Ad
-        r_norm = numpy.sum(r * r)
+        r -= alpha * Ad  # update residuals
+        r_norm = numpy.sum(r * r)  # inner product
         beta = r_norm / rk_norm
         rk_norm = r_norm
-        d[1:-1, 1:-1] = r + beta * d[1:-1, 1:-1]
+        d[1:-1, 1:-1] = r + beta * d[1:-1, 1:-1]  # update search direction
         if bc_type == 'neumann':
             fill_guard_cells_neumann(d, bc_val, dx, dy)
         res = r_norm

--- a/mae6225/poisson/cg.py
+++ b/mae6225/poisson/cg.py
@@ -1,0 +1,86 @@
+"""Routine to solve the Poisson system with Conjugate-Gradient."""
+
+import numpy
+
+
+def solve_cg(grid, ivar, rvar, maxiter=1000, tol=1e-9, verbose=False):
+    """Solve the Poisson system using a conjugate-gradient method.
+
+    Arguments
+    ---------
+    grid : Grid object
+        Grid containing data.
+    ivar : string
+        Name of the grid variable of the numerical solution.
+    rvar : string
+        Name of the grid variable of the right-hand side.
+    M : numpy.ndarray, optional
+        Preconditioner; default: None (no preconditioner).
+    maxiter : integer, optional
+        Maximum number of iterations;
+        default: 3000
+    tol : float, optional
+        Exit-criterion tolerance;
+        default: 1e-9
+
+    Returns
+    -------
+    ites: integer
+        Number of iterations computed.
+    residual: float
+        Final residual.
+    verbose : bool, optional
+        Set True to display convergence information;
+        default: False.
+
+    """
+    def A(p):
+        return ((p[:-2, 1:-1] - 2 * p[1:-1, 1:-1] + p[2:, 1:-1]) / dx**2 +
+                (p[1:-1, :-2] - 2 * p[1:-1, 1:-1] + p[1:-1, 2:]) / dy**2)
+
+    def fill_guard_cells_neumann(x, bc_val, dx, dy):
+        x[0, :] = bc_val * dx + x[1, :]
+        x[-1, :] = bc_val * dx + x[-2, :]
+        x[:, 0] = bc_val * dy + x[:, 1]
+        x[:, -1] = bc_val * dy + x[:, -2]
+
+    p = grid.get_values(ivar)
+    b = grid.get_values(rvar)
+    dx, dy = grid.dx, grid.dy
+
+    r = b[1:-1, 1:-1] - A(p)
+    rk_norm = numpy.sum(r * r)
+    d = numpy.zeros_like(p)
+    d[1:-1, 1:-1] = r
+
+    # Check for Neumann boundary conditions.
+    bc_type, bc_val = grid.bc_type[ivar][0], grid.bc_val[ivar][0]
+    if bc_type == 'neumann':
+        # Apply Neumann boundary conditions to search direction.
+        fill_guard_cells_neumann(d, bc_val, dx, dy)
+
+    ites = 0
+    res = tol + 1.0
+    while ites < maxiter and res > tol:
+        Ad = A(d)
+        alpha = rk_norm / numpy.sum(d[1:-1, 1:-1] * Ad)
+        p[1:-1, 1:-1] += alpha * d[1:-1, 1:-1]
+        grid.fill_guard_cells(ivar)
+        r -= alpha * Ad
+        r_norm = numpy.sum(r * r)
+        beta = r_norm / rk_norm
+        rk_norm = r_norm
+        d[1:-1, 1:-1] = r + beta * d[1:-1, 1:-1]
+        if bc_type == 'neumann':
+            fill_guard_cells_neumann(d, bc_val, dx, dy)
+        res = r_norm
+        ites += 1
+
+    if verbose:
+        print('CG method:')
+        if ites == maxiter:
+            print('Warning: maximum number of iterations reached!')
+        print('- Number of iterations: {}'.format(ites))
+        print('- Final residual: {}'.format(res))
+
+    return ites, res

--- a/mae6225/poisson/jacobi.py
+++ b/mae6225/poisson/jacobi.py
@@ -1,4 +1,4 @@
-"""Module with iterative solvers for the Poisson system."""
+"""Routine to solve the Poisson system with Jacobi."""
 
 import numpy
 

--- a/tests/all.py
+++ b/tests/all.py
@@ -3,7 +3,8 @@
 import sys
 import unittest
 
-tests = ['grid.grid', 'poisson.jacobi', 'poisson.sor', 'poisson.gauss']
+tests = ['grid.grid', 'poisson.jacobi', 'poisson.sor', 'poisson.gauss',
+         'poisson.cg']
 
 suite = unittest.TestSuite()
 

--- a/tests/poisson/cg.py
+++ b/tests/poisson/cg.py
@@ -1,0 +1,87 @@
+"""Tests for `mae6225/poisson/cg.py`."""
+
+import numpy
+import random
+import unittest
+
+import mae6225
+
+
+class TestPoissonCG(unittest.TestCase):
+    """Unit-tests for the Poisson CG solver."""
+
+    def setUp(self):
+        """Set up the grid and the variables of the Poisson system."""
+        center_vars = ['ivar', 'rvar', 'asol', 'eror']
+        nx, ny = 40, 40
+        xmin, xmax = 0.0, 1.0
+        ymin, ymax = -0.5, 0.5
+        bc_type = {'ivar': 4 * ['dirichlet']}
+        bc_val = {'ivar': 4 * [0.0]}
+        self.grid = mae6225.Grid('cell-centered',
+                                 center_vars,
+                                 nx, ny,
+                                 xmin, xmax, ymin, ymax,
+                                 user_bc_type=bc_type, user_bc_val=bc_val)
+        self._set_analytical('asol')
+        self._set_rhs('rvar')
+
+    def _set_analytical(self, var_name):
+        """Private method to set the analytical solution."""
+        X, Y = numpy.meshgrid(self.grid.x, self.grid.y)
+        Lx = self.grid.xmax - self.grid.xmin
+        Ly = self.grid.ymax - self.grid.ymin
+        values = numpy.sin(numpy.pi * X / Lx) * numpy.cos(numpy.pi * Y / Ly)
+        self.grid.set_values(var_name, values)
+
+    def _set_rhs(self, var_name):
+        """Private method to set the right-hand side of the system."""
+        X, Y = numpy.meshgrid(self.grid.x, self.grid.y)
+        Lx = self.grid.xmax - self.grid.xmin
+        Ly = self.grid.ymax - self.grid.ymin
+        values = (-((numpy.pi / Lx)**2 + (numpy.pi / Ly)**2) *
+                  numpy.sin(numpy.pi * X / Lx) *
+                  numpy.cos(numpy.pi * Y / Ly))
+        self.grid.set_values(var_name, values)
+
+    def test_number_of_iterations(self):
+        """Test the solver reaches the maximum number of iterations."""
+        maxiter, tol = 0, 1e-12
+        ites, _ = mae6225.poisson.solve_cg(self.grid, 'ivar', 'rvar',
+                                           maxiter=maxiter, tol=tol)
+        self.assertEqual(ites, maxiter)
+        maxiter, tol = 10, 1e-12
+        ites, _ = mae6225.poisson.solve_cg(self.grid, 'ivar', 'rvar',
+                                           maxiter=maxiter, tol=tol)
+        self.assertEqual(ites, maxiter)
+
+    def test_residual(self):
+        """Test the solver convergence."""
+        maxiter, tol = 3000, 1e-6
+        ites, res = mae6225.poisson.solve_cg(self.grid, 'ivar', 'rvar',
+                                             maxiter=maxiter, tol=tol)
+        self.assertTrue(res <= tol)
+        self.assertTrue(ites < maxiter)
+
+    def test_error(self):
+        """Test the solver results as we decrease the exit tolerance."""
+        maxiter, tol = 3000, 1e-3
+        ites1, res1 = mae6225.poisson.solve_cg(self.grid, 'ivar', 'rvar',
+                                               maxiter=maxiter, tol=tol)
+        self.grid.get_error('eror', 'ivar', 'asol')
+        error1 = numpy.max(numpy.abs(self.grid.get_values('eror')))
+        # Reset numerical solutio for second solve
+        self.grid.set_values('ivar', numpy.zeros((self.grid.nx + 2,
+                                                  self.grid.ny + 2)))
+        maxiter, tol = 3000, 1e-6
+        ites2, res2 = mae6225.poisson.solve_cg(self.grid, 'ivar', 'rvar',
+                                               maxiter=maxiter, tol=tol)
+        self.grid.get_error('eror', 'ivar', 'asol')
+        error2 = numpy.max(numpy.abs(self.grid.get_values('eror')))
+        self.assertTrue(ites1 <= ites2)
+        self.assertTrue(res1 >= res2)
+        self.assertTrue(error1 >= error2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I used @egregorio 's work-in-progress implementation to start with.
Thank you @egregorio !

Added:

* Routine `poisson.solve_cg()`.
* Unit-tests for the Poisson solver with CG.
* Fill guard cells during grid initialization.